### PR TITLE
Add yamlconfig:"omitempty" support for optional config fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - Easy loading and decoding of YAML files into Go structs.
 - Deep validation of nested structs to ensure all required configuration items are present and correctly formatted.
+- Optional fields support via a custom `yamlconfig:"omitempty"` tag, allowing certain configuration fields to be omitted.
 - Custom error messages for missing or invalid configuration items.
 - Support for a wide range of field types within configuration structs.
 
@@ -34,6 +35,25 @@ The following types are supported in your Config struct and will be validated ag
 - Bool
 - Slice/Array/Map
 - Struct
+
+### Optional Fields
+
+By default, YAMLConfig expects all fields to be present and non-empty. However, you may have optional fields that you want to allow missing or empty values for. To mark a field as optional, annotate it with the yamlconfig:"omitempty" tag. If a field is empty and is marked as omitempty, it will not produce a validation error.
+
+#### Example
+
+```go
+type Config struct {
+    Service string            `yaml:"service"`
+    Image   string            `yaml:"image"`
+    Servers []string          `yaml:"servers"`
+    Env     map[string]string `yaml:"env" yamlconfig:"omitempty"`
+    Volumes []string          `yaml:"volumes" yamlconfig:"omitempty"`
+    Ports   []string          `yaml:"ports" yamlconfig:"omitempty"`
+}
+```
+
+In this example, Env, Volumes, and Ports fields are optional. If your YAML file omits these fields or leaves them empty, YAMLConfig will not return an error during validation.
 
 ### Creating a Configuration File
 


### PR DESCRIPTION
This PR introduces support for optional fields in configuration structs by leveraging a new `yamlconfig:"omitempty"` tag. Previously, all fields defined in the configuration structs were treated as required, and an error was returned if they were missing or empty. With this change, fields tagged as omitempty can now be safely omitted or left empty in the YAML configuration file without causing validation failures.

### Key Changes:

New omitempty Tag Support:
Fields annotated with `yamlconfig:"omitempty"` will no longer trigger validation errors if missing or empty. This provides flexibility for configurations that have non-critical or optional values.

### Updated Validation Logic:
The validation process now checks for the `omitempty` tag before determining if a field’s absence should result in an error. Required fields without this tag maintain their existing strict validation rules.

### Extended Documentation:
The README.md has been updated to document how to use `yamlconfig:"omitempty"` and clarify which fields can be optional.

### Additional Unit Tests:
New tests were added to confirm that fields marked as optional can be omitted without errors, and that required fields still behave as expected. These tests ensure both backward compatibility and correct handling of optional fields.

### Why This Feature?
Many applications have configuration fields that are not always necessary. Providing a mechanism to mark certain fields as optional simplifies deployment and encourages more flexible configuration files, reducing the need to create multiple configuration variants or workarounds for non-critical settings.

### How to Use It:
Add `yamlconfig:"omitempty"` to any field in your config struct that should be optional. For example:

```go
type Config struct {
    Service string            `yaml:"service"`
    Image   string            `yaml:"image"`
    Env     map[string]string `yaml:"env" yamlconfig:"omitempty"`
    Volumes []string          `yaml:"volumes" yamlconfig:"omitempty"`
    Ports   []string          `yaml:"ports" yamlconfig:"omitempty"`
}
```

If Env, Volumes, or Ports are omitted from the YAML, or empty, they will not produce validation errors.

### Testing & Verification:

Ran the test suite (make test) to ensure no regressions.
Confirmed that omitting optional fields no longer causes errors.
Verified that removing a required field still returns an appropriate validation error.
This PR is fully backward compatible for existing users who do not use the omitempty tag and ensures a smoother experience for configurations that may evolve over time.