### PR TITLE
fix: allow boolean false as valid config value

### DIFF
--- a/yamlconfig.go
+++ b/yamlconfig.go
@@ -108,7 +108,7 @@ func isEmpty(v reflect.Value) bool {
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
 	case reflect.Bool:
-		return !v.Bool()
+		return false
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
 			if !isEmpty(v.Field(i)) {

--- a/yamlconfig_test.go
+++ b/yamlconfig_test.go
@@ -193,4 +193,27 @@ func TestConfig(t *testing.T) {
 		loadConfigErr := yamlconfig.LoadConfig(tempConfigFile.Name(), &cfg)
 		require.Error(t, loadConfigErr)
 	})
+
+	t.Run("Load Config with Bool Field - False", func(t *testing.T) {
+		cfg := TestConfigStruct{}
+		tempConfigFile, tempConfigFileErr := os.CreateTemp("", "config_bool_false.yml")
+		require.NoError(t, tempConfigFileErr)
+		defer os.Remove(tempConfigFile.Name())
+
+		_, writeStringErr := tempConfigFile.WriteString("string: test\nint: 1\nbool: false\nslice:\n  - foo\n  - bar\nunit: 1\nfloat: 1.0\nstruct:\n  string: test")
+		if writeStringErr != nil {
+			t.Fatal(writeStringErr)
+		}
+
+		loadConfigErr := yamlconfig.LoadConfig(tempConfigFile.Name(), &cfg)
+		require.NoError(t, loadConfigErr)
+
+		require.Equal(t, "test", cfg.String)
+		require.Equal(t, 1, cfg.Int)
+		require.Equal(t, false, cfg.Bool)
+		require.Equal(t, []string{"foo", "bar"}, cfg.Slice)
+		require.Equal(t, uint(1), cfg.Unit)
+		require.Equal(t, 1.0, cfg.Float)
+		require.Equal(t, "test", cfg.Struct.String)
+	})
 }


### PR DESCRIPTION
Updated the isEmpty check for bool fields to always return false. This prevents valid false values from triggering a "missing required config item" error.